### PR TITLE
Refactor/harden Kea types

### DIFF
--- a/x-pack/plugins/enterprise_search/public/applications/shared/types.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/shared/types.ts
@@ -29,3 +29,13 @@ export interface IKeaSelectors<IKeaValues> {
 export interface IKeaListeners<IKeaActions> {
   actions: IKeaActions;
 }
+
+export interface IKeaReducers<IKeaValues> {
+  [value: string]: [
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    any, // The default state for the value - can be anything
+    {
+      [action: string]: (state: IKeaValues, payload: IKeaValues) => void; // Returns new state
+    }
+  ];
+}

--- a/x-pack/plugins/enterprise_search/public/applications/shared/types.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/shared/types.ts
@@ -46,3 +46,20 @@ export type TKeaReducers<IKeaValues, IKeaActions> = {
     }
   ];
 };
+
+/**
+ * This selectors() type checks that:
+ *
+ * 1. The object keys are defined within IKeaValues
+ * 2. The selected values are defined within IKeaValues
+ * 3. The returned value match the type definition within IKeaValues
+ *
+ * The unknown[] and any[] are unfortunately because I have no idea how to
+ * assert for arbitrary type/values as an array
+ */
+export type TKeaSelectors<IKeaValues> = {
+  [Value in keyof IKeaValues]?: [
+    (selectors: IKeaValues) => unknown[],
+    (...args: any[]) => IKeaValues[Value] // eslint-disable-line @typescript-eslint/no-explicit-any
+  ];
+};

--- a/x-pack/plugins/enterprise_search/public/applications/shared/types.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/shared/types.ts
@@ -17,17 +17,22 @@ export interface IKeaLogic<IKeaValues, IKeaActions> {
   mount(): void;
   values: IKeaValues;
   actions: IKeaActions;
-  reducers(): object;
-  selectors?(): object;
-  listeners?(): object;
 }
 
-export interface IKeaSelectors<IKeaValues> {
-  selectors: IKeaValues;
-}
-
-export interface IKeaListeners<IKeaActions> {
-  actions: IKeaActions;
+/**
+ * This reusable interface mostly saves us a few characters / allows us to skip
+ * defining params inline. Unfortunately, the return values *do not work* as
+ * expected (hence the voids).  While I can tell selectors to use TKeaSelectors,
+ * the return value is *not* properly type checked if it's not declared inline. :/
+ *
+ * Also note that if you switch to Kea 2.1's plain object notation -
+ * `selectors: {}` vs. `selectors: () => ({})`
+ * - type checking also stops working and type errors become significantly less
+ * helpful - showing less specific error messages and highlighting. 👎
+ */
+export interface IKeaParams<IKeaValues, IKeaActions> {
+  selectors?(params: { selectors: IKeaValues }): void;
+  listeners?(params: { actions: IKeaActions; values: IKeaValues }): void;
 }
 
 /**

--- a/x-pack/plugins/enterprise_search/public/applications/shared/types.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/shared/types.ts
@@ -30,12 +30,19 @@ export interface IKeaListeners<IKeaActions> {
   actions: IKeaActions;
 }
 
-export interface IKeaReducers<IKeaValues> {
-  [value: string]: [
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    any, // The default state for the value - can be anything
+/**
+ * This reducers() type checks that:
+ *
+ * 1. The value object keys are defined within IKeaValues
+ * 2. The default state (array[0]) matches the type definition within IKeaValues
+ * 3. The action object keys (array[1]) are defined within IKeaActions
+ * 3. The new state returned by the action matches the type definition within IKeaValues
+ */
+export type TKeaReducers<IKeaValues, IKeaActions> = {
+  [Value in keyof IKeaValues]?: [
+    IKeaValues[Value],
     {
-      [action: string]: (state: IKeaValues, payload: IKeaValues) => void; // Returns new state
+      [Action in keyof IKeaActions]?: (state: IKeaValues, payload: IKeaValues) => IKeaValues[Value];
     }
   ];
-}
+};

--- a/x-pack/plugins/enterprise_search/public/applications/shared/types.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/shared/types.ts
@@ -13,10 +13,19 @@ export interface IFlashMessagesProps {
   children?: React.ReactNode;
 }
 
-export interface IKeaLogic {
+export interface IKeaLogic<IKeaValues, IKeaActions> {
   mount(): void;
-  values: object;
+  values: IKeaValues;
+  actions: IKeaActions;
   reducers(): object;
   selectors?(): object;
   listeners?(): object;
+}
+
+export interface IKeaSelectors<IKeaValues> {
+  selectors: IKeaValues;
+}
+
+export interface IKeaListeners<IKeaActions> {
+  actions: IKeaActions;
 }

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/components/overview/overview_logic.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/components/overview/overview_logic.ts
@@ -12,6 +12,7 @@ import { IAccount, IOrganization, IUser } from '../../types';
 import {
   IFlashMessagesProps,
   IKeaLogic,
+  IKeaReducers,
   IKeaSelectors,
   IKeaListeners,
 } from '../../../shared/types';
@@ -57,102 +58,95 @@ export const OverviewLogic = kea({
     setHasErrorConnecting: (hasErrorConnecting) => ({ hasErrorConnecting }),
     initializeOverview: ({ http }) => ({ http }),
   }),
-  reducers: () => ({
+  reducers: (): IKeaReducers<IOverviewValues> => ({
     organization: [
       {},
       {
-        setServerData: (_: IOverviewValues, { organization }: IOverviewValues) => organization,
+        setServerData: (_, { organization }) => organization,
       },
     ],
     isFederatedAuth: [
       true,
       {
-        setServerData: (_: IOverviewValues, { isFederatedAuth }: IOverviewValues) =>
-          isFederatedAuth,
+        setServerData: (_, { isFederatedAuth }) => isFederatedAuth,
       },
     ],
     currentUser: [
       {},
       {
-        setServerData: (_: IOverviewValues, { currentUser }: IOverviewValues) => currentUser,
+        setServerData: (_, { currentUser }) => currentUser,
       },
     ],
     fpAccount: [
       {},
       {
-        setServerData: (_: IOverviewValues, { fpAccount }: IOverviewValues) => fpAccount,
+        setServerData: (_, { fpAccount }) => fpAccount,
       },
     ],
     canCreateInvitations: [
       false,
       {
-        setServerData: (_: IOverviewValues, { canCreateInvitations }: IOverviewValues) =>
-          canCreateInvitations,
+        setServerData: (_, { canCreateInvitations }) => canCreateInvitations,
       },
     ],
     flashMessages: [
       {},
       {
-        setFlashMessages: (_: IOverviewValues, { flashMessages }: IOverviewValues) => flashMessages,
+        setFlashMessages: (_, { flashMessages }) => flashMessages,
       },
     ],
     hasUsers: [
       false,
       {
-        setServerData: (_: IOverviewServerData, { hasUsers }: IOverviewValues) => hasUsers,
+        setServerData: (_, { hasUsers }) => hasUsers,
       },
     ],
     hasOrgSources: [
       false,
       {
-        setServerData: (_: IOverviewServerData, { hasOrgSources }: IOverviewValues) =>
-          hasOrgSources,
+        setServerData: (_, { hasOrgSources }) => hasOrgSources,
       },
     ],
     canCreateContentSources: [
       false,
       {
-        setServerData: (_: IOverviewServerData, { canCreateContentSources }: IOverviewValues) =>
-          canCreateContentSources,
+        setServerData: (_, { canCreateContentSources }) => canCreateContentSources,
       },
     ],
     isOldAccount: [
       false,
       {
-        setServerData: (_: IOverviewServerData, { isOldAccount }: IOverviewValues) => isOldAccount,
+        setServerData: (_, { isOldAccount }) => isOldAccount,
       },
     ],
     sourcesCount: [
       0,
       {
-        setServerData: (_: IOverviewServerData, { sourcesCount }: IOverviewValues) => sourcesCount,
+        setServerData: (_, { sourcesCount }) => sourcesCount,
       },
     ],
     pendingInvitationsCount: [
       0,
       {
-        setServerData: (_: IOverviewServerData, { pendingInvitationsCount }: IOverviewValues) =>
-          pendingInvitationsCount,
+        setServerData: (_, { pendingInvitationsCount }) => pendingInvitationsCount,
       },
     ],
     accountsCount: [
       0,
       {
-        setServerData: (_: IOverviewServerData, { accountsCount }: IOverviewValues) =>
-          accountsCount,
+        setServerData: (_, { accountsCount }) => accountsCount,
       },
     ],
     personalSourcesCount: [
       0,
       {
-        setServerData: (_: IOverviewServerData, { personalSourcesCount }: IOverviewValues) =>
-          personalSourcesCount,
+        setServerData: (_, { personalSourcesCount }) => personalSourcesCount,
       },
     ],
     activityFeed: [
       [],
       {
-        setServerData: (_: IOverviewServerData, { activityFeed }: IOverviewValues) => activityFeed,
+        setServerData: (_, { activityFeed }) => activityFeed,
       },
     ],
     dataLoading: [
@@ -165,8 +159,7 @@ export const OverviewLogic = kea({
     hasErrorConnecting: [
       false,
       {
-        setHasErrorConnecting: (_: IOverviewServerData, { hasErrorConnecting }: IOverviewValues) =>
-          hasErrorConnecting,
+        setHasErrorConnecting: (_, { hasErrorConnecting }) => hasErrorConnecting,
       },
     ],
   }),

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/components/overview/overview_logic.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/components/overview/overview_logic.ts
@@ -55,12 +55,10 @@ interface IOverviewLogic extends IKeaLogic, IListenerParams {
 
 export const OverviewLogic = kea({
   actions: (): IOverviewActions => ({
-    setServerData: (serverData: IOverviewServerData) => serverData,
-    setFlashMessages: (flashMessages: IFlashMessagesProps) => ({
-      flashMessages,
-    }),
-    setHasErrorConnecting: (hasErrorConnecting: boolean) => ({ hasErrorConnecting }),
-    initializeOverview: ({ http }: { http: HttpSetup }) => ({ http }),
+    setServerData: (serverData) => serverData,
+    setFlashMessages: (flashMessages) => ({ flashMessages }),
+    setHasErrorConnecting: (hasErrorConnecting) => ({ hasErrorConnecting }),
+    initializeOverview: ({ http }) => ({ http }),
   }),
   reducers: () => ({
     organization: [

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/components/overview/overview_logic.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/components/overview/overview_logic.ts
@@ -13,6 +13,7 @@ import {
   IFlashMessagesProps,
   IKeaLogic,
   TKeaReducers,
+  TKeaSelectors,
   IKeaSelectors,
   IKeaListeners,
 } from '../../../shared/types';
@@ -163,7 +164,7 @@ export const OverviewLogic = kea({
       },
     ],
   }),
-  selectors: ({ selectors }: IKeaSelectors<IOverviewValues>) => ({
+  selectors: ({ selectors }: IKeaSelectors<IOverviewValues>): TKeaSelectors<IOverviewValues> => ({
     hideOnboarding: [
       () => [
         selectors.hasUsers,
@@ -179,7 +180,7 @@ export const OverviewLogic = kea({
       (isFederatedAuth: boolean) => (isFederatedAuth ? 'halves' : 'fourths'),
     ],
   }),
-  listeners: ({ actions }: IKeaListeners<IOverviewActions>) => ({
+  listeners: ({ actions }: IKeaListeners<IOverviewActions>): Partial<IOverviewActions> => ({
     initializeOverview: async ({ http }: { http: HttpSetup }) => {
       try {
         const response = await http.get('/api/workplace_search/overview');

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/components/overview/overview_logic.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/components/overview/overview_logic.ts
@@ -9,7 +9,12 @@ import { HttpSetup } from 'src/core/public';
 import { kea } from 'kea';
 
 import { IAccount, IOrganization, IUser } from '../../types';
-import { IFlashMessagesProps, IKeaLogic } from '../../../shared/types';
+import {
+  IFlashMessagesProps,
+  IKeaLogic,
+  IKeaSelectors,
+  IKeaListeners,
+} from '../../../shared/types';
 
 import { IFeedActivity } from './recent_activity';
 
@@ -43,14 +48,6 @@ export interface IOverviewValues extends IOverviewServerData {
   statsColumns: 'halves' | 'fourths';
   hasErrorConnecting: boolean;
   flashMessages: IFlashMessagesProps;
-}
-
-interface IListenerParams {
-  actions: IOverviewActions;
-}
-
-interface IOverviewLogic extends IKeaLogic, IListenerParams {
-  values: IOverviewValues;
 }
 
 export const OverviewLogic = kea({
@@ -173,7 +170,7 @@ export const OverviewLogic = kea({
       },
     ],
   }),
-  selectors: ({ selectors }: { selectors: IOverviewValues }) => ({
+  selectors: ({ selectors }: IKeaSelectors<IOverviewValues>) => ({
     hideOnboarding: [
       () => [
         selectors.hasUsers,
@@ -189,7 +186,7 @@ export const OverviewLogic = kea({
       (isFederatedAuth: boolean) => (isFederatedAuth ? 'halves' : 'fourths'),
     ],
   }),
-  listeners: ({ actions }: IListenerParams) => ({
+  listeners: ({ actions }: IKeaListeners<IOverviewActions>) => ({
     initializeOverview: async ({ http }: { http: HttpSetup }) => {
       try {
         const response = await http.get('/api/workplace_search/overview');
@@ -199,4 +196,4 @@ export const OverviewLogic = kea({
       }
     },
   }),
-}) as IOverviewLogic;
+}) as IKeaLogic<IOverviewValues, IOverviewActions>;

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/components/overview/overview_logic.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/components/overview/overview_logic.ts
@@ -14,8 +14,7 @@ import {
   IKeaLogic,
   TKeaReducers,
   TKeaSelectors,
-  IKeaSelectors,
-  IKeaListeners,
+  IKeaParams,
 } from '../../../shared/types';
 
 import { IFeedActivity } from './recent_activity';
@@ -164,7 +163,7 @@ export const OverviewLogic = kea({
       },
     ],
   }),
-  selectors: ({ selectors }: IKeaSelectors<IOverviewValues>): TKeaSelectors<IOverviewValues> => ({
+  selectors: ({ selectors }): TKeaSelectors<IOverviewValues> => ({
     hideOnboarding: [
       () => [
         selectors.hasUsers,
@@ -180,7 +179,7 @@ export const OverviewLogic = kea({
       (isFederatedAuth: boolean) => (isFederatedAuth ? 'halves' : 'fourths'),
     ],
   }),
-  listeners: ({ actions }: IKeaListeners<IOverviewActions>): Partial<IOverviewActions> => ({
+  listeners: ({ actions }): Partial<IOverviewActions> => ({
     initializeOverview: async ({ http }: { http: HttpSetup }) => {
       try {
         const response = await http.get('/api/workplace_search/overview');
@@ -190,4 +189,4 @@ export const OverviewLogic = kea({
       }
     },
   }),
-}) as IKeaLogic<IOverviewValues, IOverviewActions>;
+} as IKeaParams<IOverviewValues, IOverviewActions>) as IKeaLogic<IOverviewValues, IOverviewActions>;

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/components/overview/overview_logic.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/components/overview/overview_logic.ts
@@ -12,7 +12,7 @@ import { IAccount, IOrganization, IUser } from '../../types';
 import {
   IFlashMessagesProps,
   IKeaLogic,
-  IKeaReducers,
+  TKeaReducers,
   IKeaSelectors,
   IKeaListeners,
 } from '../../../shared/types';
@@ -58,9 +58,9 @@ export const OverviewLogic = kea({
     setHasErrorConnecting: (hasErrorConnecting) => ({ hasErrorConnecting }),
     initializeOverview: ({ http }) => ({ http }),
   }),
-  reducers: (): IKeaReducers<IOverviewValues> => ({
+  reducers: (): TKeaReducers<IOverviewValues, IOverviewActions> => ({
     organization: [
-      {},
+      {} as IOrganization,
       {
         setServerData: (_, { organization }) => organization,
       },
@@ -72,13 +72,13 @@ export const OverviewLogic = kea({
       },
     ],
     currentUser: [
-      {},
+      {} as IUser,
       {
         setServerData: (_, { currentUser }) => currentUser,
       },
     ],
     fpAccount: [
-      {},
+      {} as IAccount,
       {
         setServerData: (_, { fpAccount }) => fpAccount,
       },


### PR DESCRIPTION
This was a lot of me playing around with and learning a lot of Typescript. The end result is that (IMO) `overview_logic.ts` is a little cleaner/less repetitive with its definitions, but **also** has stronger type/regression checking.