### PR TITLE
Kea 22 upgrade, part 2

### DIFF
--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/components/overview/overview_logic.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/components/overview/overview_logic.ts
@@ -9,7 +9,7 @@ import { HttpSetup } from 'src/core/public';
 import { kea, MakeLogicType } from 'kea';
 
 import { IAccount, IOrganization, IUser } from '../../types';
-import { IFlashMessagesProps, TKeaReducers } from '../../../shared/types';
+import { IFlashMessagesProps } from '../../../shared/types';
 
 import { IFeedActivity } from './recent_activity';
 
@@ -31,10 +31,10 @@ export interface IOverviewServerData {
 }
 
 export interface IOverviewActions {
-  setServerData(serverData: IOverviewServerData): void;
-  setFlashMessages(flashMessages: IFlashMessagesProps): void;
-  setHasErrorConnecting(hasErrorConnecting: boolean): void;
-  initializeOverview({ http }: { http: HttpSetup }): void;
+  setServerData(serverData: IOverviewServerData): IOverviewServerData;
+  setFlashMessages(flashMessages: IFlashMessagesProps): { flashMessages: IFlashMessagesProps };
+  setHasErrorConnecting(hasErrorConnecting: boolean): { hasErrorConnecting: boolean };
+  initializeOverview({ http }: { http: HttpSetup }): { http: HttpSetup };
 }
 
 export interface IOverviewValues extends IOverviewServerData {
@@ -156,7 +156,7 @@ export const OverviewLogic = kea<MakeLogicType<IOverviewValues, IOverviewActions
     ],
   },
   listeners: ({ actions }) => ({
-    initializeOverview: async ({ http }: { http: HttpSetup }) => {
+    initializeOverview: async ({ http }) => {
       try {
         const response = await http.get('/api/workplace_search/overview');
         actions.setServerData(response);

--- a/yarn.lock
+++ b/yarn.lock
@@ -19522,10 +19522,10 @@ kdbush@^3.0.0:
   resolved "https://registry.yarnpkg.com/kdbush/-/kdbush-3.0.0.tgz#f8484794d47004cc2d85ed3a79353dbe0abc2bf0"
   integrity sha512-hRkd6/XW4HTsA9vjVpY9tuXJYLSlelnkTmVFu4M9/7MIYQtFcHpbugAU7UbOfjOiVSVYl2fqgBuJ32JUmRo5Ew==
 
-kea@2.2.0-beta.8:
-  version "2.2.0-beta.8"
-  resolved "https://registry.yarnpkg.com/kea/-/kea-2.2.0-beta.8.tgz#c44232dff2143fe3edea89c0eeae871588a5525d"
-  integrity sha512-CiIjRsBhzc3a387owOD9fsTL20ACvdiUr+lgWwBEYkDl69Sogm5+IuihYQYidrbkmatGrCXtbD7Ly9fPaStbqA==
+kea@2.2.0-rc.2:
+  version "2.2.0-rc.2"
+  resolved "https://registry.yarnpkg.com/kea/-/kea-2.2.0-rc.2.tgz#1c04110dca4b4c475fb0b0f40a5bfbe609058d40"
+  integrity sha512-N1ytphLYPeUmrqpal78mdZextJkO2Gzj8LQI3bahM/NagYSX8biAYS6FhJeGJfaySChkBf2zbL2hvfrScKap3A==
 
 kew@~0.1.7:
   version "0.1.7"


### PR DESCRIPTION
## Summary

- Commit the root `yarn.lock` file, which contains a reference to `kea-2.2.0-rc.2`
![2020-08-18 22 42 45](https://user-images.githubusercontent.com/53387/90563855-b1accf00-e1a4-11ea-97f8-c226a9ce4a58.gif)

- Also Add return types to `IOverviewActions` to make actions have the right types in reducers:
![2020-08-18 22 43 16](https://user-images.githubusercontent.com/53387/90563860-b3769280-e1a4-11ea-9628-5dfce073b6a7.gif)


### Checklist

Delete any items that are not applicable to this PR.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/master/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] This was checked for [keyboard-only and screenreader accessibility](https://developer.mozilla.org/en-US/docs/Learn/Tools_and_testing/Cross_browser_testing/Accessibility#Accessibility_testing_checklist)
- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server)
- [ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)

### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
